### PR TITLE
fix(web): add missing tailwind and postcss configs

### DIFF
--- a/web-portal/postcss.config.js
+++ b/web-portal/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/web-portal/tailwind.config.js
+++ b/web-portal/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}


### PR DESCRIPTION
These files were missing from the repository, causing the CI/CD build to fail when compiling CSS. Adding them ensures the pipeline build matches the local build.