### PR TITLE
fix(seo): restore 'no monthly fee' phrase in footer brand line with h…

### DIFF
--- a/web-portal/src/components/Footer.tsx
+++ b/web-portal/src/components/Footer.tsx
@@ -13,7 +13,7 @@ const Footer: React.FC = () => {
           <div className="md:col-span-2">
             <p className="text-lg font-bold text-white">BusinessCart.ai</p>
             <p className="mt-2 text-sm text-gray-300">
-              Your own branded online store with a free Starter tier. Built-in B2B, sub-1-second loads, and AI-ready storefronts.
+              Your own branded online store with no monthly fee on the Starter tier &mdash; pay 6% per order, capped at $5. Built-in B2B, sub-1-second loads, and AI-ready storefronts.
             </p>
             <div className="mt-4 space-y-2">
               <p className="text-sm text-gray-300">


### PR DESCRIPTION
…onest 6%-capped-at- qualifier (recovers site-wide topical signal lost on 6e703c5)