### PR TITLE
feat(storefront): policy pages render company text only (no platform …

### DIFF
--- a/account-service/internal/generator/generator.go
+++ b/account-service/internal/generator/generator.go
@@ -749,14 +749,20 @@ func (g *Generator) renderTemplate(tmplName, outputPath string, data interface{}
 			return slugify(primary) + "-" + slugify(sub)
 		},
 		"safeHTML": func(s string) template.HTML {
-			// Allow only p, strong, br, em tags — strip everything else
-			safe := strings.ReplaceAll(s, "<script", "&lt;script")
-			safe = strings.ReplaceAll(safe, "<iframe", "&lt;iframe")
-			safe = strings.ReplaceAll(safe, "<img", "&lt;img")
-			safe = strings.ReplaceAll(safe, "<a ", "&lt;a ")
-			safe = strings.ReplaceAll(safe, "onclick", "")
-			safe = strings.ReplaceAll(safe, "onerror", "")
-			return template.HTML(safe)
+			// Allowlist: escape EVERYTHING, then re-allow a tiny set of
+			// formatting tags. Attributes are never allowed (no <a href>,
+			// no onclick/onerror, no style). This is rendered into
+			// company-controlled marketing pages (about/privacy/terms/
+			// shipping) where the operator wants light formatting only.
+			esc := template.HTMLEscapeString(s)
+			tags := []string{"p", "br", "strong", "em", "ul", "li", "h2"}
+			for _, t := range tags {
+				esc = strings.ReplaceAll(esc, "&lt;"+t+"&gt;", "<"+t+">")
+				esc = strings.ReplaceAll(esc, "&lt;/"+t+"&gt;", "</"+t+">")
+			}
+			esc = strings.ReplaceAll(esc, "&lt;br/&gt;", "<br/>")
+			esc = strings.ReplaceAll(esc, "&lt;br /&gt;", "<br />")
+			return template.HTML(esc)
 		},
 		"catCount": func(counts map[string]int, cat string) int {
 			return counts[cat]

--- a/account-service/internal/generator/templates/privacy.html
+++ b/account-service/internal/generator/templates/privacy.html
@@ -20,7 +20,11 @@
         h2 { font-size: 1.4rem; font-weight: 700; margin: 2rem 0 0.75rem; }
         main p, main li { color: #475569; } ul { padding-left: 1.5rem; }
         .last-updated { color: #94a3b8; font-size: 0.9rem; margin-bottom: 2rem; }
-        .custom-text { white-space: pre-wrap; color: #475569; background: #f1f5f9; border-radius: 8px; padding: 1.5rem; margin: 1rem 0; }
+        .custom-text { color: #475569; margin: 1rem 0; }
+        .custom-text h2 { font-size: 1.4rem; font-weight: 700; margin: 2rem 0 0.75rem; color: var(--text); }
+        .custom-text p { margin: 0 0 1rem; }
+        .custom-text ul { padding-left: 1.5rem; margin: 0 0 1rem; }
+        .custom-text li { margin-bottom: 0.25rem; }
         @media (max-width: 768px) { h1 { font-size: 2rem; } main { padding: 2rem 5%; } }
         [[template "global_css" .]]
     </style>
@@ -36,39 +40,7 @@
         <h1>Privacy Policy</h1>
         <p class="last-updated">Last updated: [[.Timestamp]]</p>
 
-        <h2>Introduction</h2>
-        <p>[[.Company.Name]] is committed to protecting your privacy. This Privacy Policy explains how we collect, use, and protect your information when you visit our store and make purchases.</p>
-
-        <h2>Information We Collect</h2>
-        <p>When you place an order or create an account, we may collect:</p>
-        <ul>
-            <li>Name, email address, and phone number</li>
-            <li>Shipping and billing address</li>
-            <li>Order history and product preferences</li>
-        </ul>
-        <p>We do not store credit card numbers or sensitive payment information. All payments are processed securely through our third-party payment provider.</p>
-
-        <h2>How We Use Your Information</h2>
-        <ul>
-            <li>To process and fulfill your orders</li>
-            <li>To send order confirmations and updates</li>
-            <li>To respond to your questions and requests</li>
-            <li>To improve our products and services</li>
-        </ul>
-
-        <h2>How We Protect Your Information</h2>
-        <p>We use industry-standard security measures to protect your personal information. All data is transmitted over encrypted connections (HTTPS). Payment processing is handled by certified third-party providers.</p>
-
-        <h2>Sharing Your Information</h2>
-        <p>We do not sell your personal information. We share your information only when necessary to fulfill your order (e.g., with shipping carriers) or when required by law.</p>
-
-        [[if .Config.PrivacyText]]
-        <h2>Additional Policies</h2>
-        <div class="custom-text">[[.Config.PrivacyText]]</div>
-        [[end]]
-
-        <h2>Your Rights</h2>
-        <p>You may request access to, correction of, or deletion of your personal information at any time by contacting us.</p>
+        <div class="custom-text">[[safeHTML .Config.PrivacyText]]</div>
 
         <h2>Contact</h2>
         <p>Questions about this Privacy Policy? Contact us:</p>

--- a/account-service/internal/generator/templates/shipping.html
+++ b/account-service/internal/generator/templates/shipping.html
@@ -23,7 +23,11 @@
         .method-card { background: white; border-radius: 12px; padding: 1.5rem; margin-bottom: 1rem; box-shadow: 0 1px 3px rgba(0,0,0,0.08); }
         .method-card h3 { font-size: 1.1rem; font-weight: 700; margin: 0 0 0.5rem 0; color: var(--text); }
         .method-card p { margin: 0.25rem 0; }
-        .custom-text { white-space: pre-wrap; color: #475569; background: #f1f5f9; border-radius: 8px; padding: 1.5rem; margin: 1rem 0; }
+        .custom-text { color: #475569; margin: 1rem 0; }
+        .custom-text h2 { font-size: 1.4rem; font-weight: 700; margin: 2rem 0 0.75rem; color: var(--text); }
+        .custom-text p { margin: 0 0 1rem; }
+        .custom-text ul { padding-left: 1.5rem; margin: 0 0 1rem; }
+        .custom-text li { margin-bottom: 0.25rem; }
         @media (max-width: 768px) { h1 { font-size: 2rem; } main { padding: 2rem 5%; } }
         [[template "global_css" .]]
     </style>
@@ -39,43 +43,7 @@
         <h1>Shipping & Returns</h1>
         <p class="subtitle">How we get orders to you and what to do if something is not right.</p>
 
-        [[if .Company.DeliveryMethods]]
-        <h2>Delivery Options</h2>
-        [[range .Company.DeliveryMethods]]
-        [[if eq (printf "%s" .) "pickup"]]
-        <div class="method-card">
-            <h3>Pickup</h3>
-            <p>Place your order online and pick it up at our location. You will receive a notification when your order is ready for pickup.</p>
-        </div>
-        [[end]]
-        [[if eq (printf "%s" .) "dropoff"]]
-        <div class="method-card">
-            <h3>Local Delivery</h3>
-            <p>We deliver directly to your location. Delivery times and availability may vary based on your area. You will be notified with delivery details after your order is confirmed.</p>
-        </div>
-        [[end]]
-        [[if eq (printf "%s" .) "shipping_out"]]
-        <div class="method-card">
-            <h3>Shipping</h3>
-            <p>We ship orders via carrier to your address. Shipping times vary by destination. You will receive tracking information once your order has shipped.</p>
-            [[if $.Company.ShippingOutOptions]]
-            <p style="margin-top: 0.5rem; font-size: 0.95rem;">Available shipping options are shown at checkout based on your location.</p>
-            [[end]]
-        </div>
-        [[end]]
-        [[end]]
-        [[end]]
-
-        <h2>Order Processing</h2>
-        <p>Orders are typically processed within 1-2 business days. You will receive an order confirmation by email after your purchase is complete. If there are any issues with your order, we will contact you directly.</p>
-
-        <h2>Returns & Exchanges</h2>
-        <p>If you are not satisfied with your purchase, please contact us to discuss a return or exchange. We handle returns on a case-by-case basis and will work with you to find a fair resolution. Please reach out within a reasonable timeframe after receiving your order.</p>
-
-        [[if .Config.ShippingText]]
-        <h2>Additional Shipping & Return Information</h2>
-        <div class="custom-text">[[.Config.ShippingText]]</div>
-        [[end]]
+        <div class="custom-text">[[safeHTML .Config.ShippingText]]</div>
 
         <h2>Questions?</h2>
         <p>Contact us for any shipping or return questions:</p>

--- a/account-service/internal/generator/templates/terms.html
+++ b/account-service/internal/generator/templates/terms.html
@@ -20,7 +20,11 @@
         h2 { font-size: 1.4rem; font-weight: 700; margin: 2rem 0 0.75rem; }
         main p, main li { color: #475569; } ul { padding-left: 1.5rem; }
         .last-updated { color: #94a3b8; font-size: 0.9rem; margin-bottom: 2rem; }
-        .custom-text { white-space: pre-wrap; color: #475569; background: #f1f5f9; border-radius: 8px; padding: 1.5rem; margin: 1rem 0; }
+        .custom-text { color: #475569; margin: 1rem 0; }
+        .custom-text h2 { font-size: 1.4rem; font-weight: 700; margin: 2rem 0 0.75rem; color: var(--text); }
+        .custom-text p { margin: 0 0 1rem; }
+        .custom-text ul { padding-left: 1.5rem; margin: 0 0 1rem; }
+        .custom-text li { margin-bottom: 0.25rem; }
         @media (max-width: 768px) { h1 { font-size: 2rem; } main { padding: 2rem 5%; } }
         [[template "global_css" .]]
     </style>
@@ -36,41 +40,7 @@
         <h1>Terms of Service</h1>
         <p class="last-updated">Last updated: [[.Timestamp]]</p>
 
-        <h2>1. Acceptance of Terms</h2>
-        <p>By accessing and using the [[.Company.Name]] online store, you agree to be bound by these Terms of Service. If you do not agree to these terms, please do not use this store.</p>
-
-        <h2>2. Products and Pricing</h2>
-        <p>All products listed on this store are offered by [[.Company.Name]]. Prices are listed in USD and are subject to change without notice. We make every effort to display accurate pricing and product information, but errors may occur. We reserve the right to correct any errors and to cancel orders placed at incorrect prices.</p>
-
-        <h2>3. Orders and Payment</h2>
-        <p>When you place an order, you agree to provide accurate and complete information. All payments are processed securely through our third-party payment provider. [[.Company.Name]] does not store your credit card information. We reserve the right to refuse or cancel any order for any reason.</p>
-
-        <h2>4. Account Responsibility</h2>
-        <p>If you create an account on this store, you are responsible for maintaining the confidentiality of your login credentials and for all activity that occurs under your account. You agree to notify us immediately of any unauthorized use of your account.</p>
-
-        [[if .Company.DeliveryMethods]]
-        <h2>5. Delivery</h2>
-        <p>[[.Company.Name]] offers the following delivery options:</p>
-        <ul>
-            [[range .Company.DeliveryMethods]]
-            [[if eq (printf "%s" .) "pickup"]]<li>Pickup — Collect your order at our location.</li>[[end]]
-            [[if eq (printf "%s" .) "dropoff"]]<li>Dropoff — We deliver to your location.</li>[[end]]
-            [[if eq (printf "%s" .) "shipping_out"]]<li>Shipping — We ship orders to your address via carrier.</li>[[end]]
-            [[end]]
-        </ul>
-        <p>Delivery times may vary. We are not responsible for delays caused by carriers or circumstances beyond our control.</p>
-        [[end]]
-
-        <h2>6. Limitation of Liability</h2>
-        <p>[[.Company.Name]] shall not be liable for any indirect, incidental, special, or consequential damages arising from your use of this store or your inability to use this store, including but not limited to loss of profits, data, or business opportunity.</p>
-
-        <h2>7. Changes to Terms</h2>
-        <p>We may update these terms from time to time. Continued use of this store after changes are posted constitutes acceptance of the updated terms.</p>
-
-        [[if .Config.TermsText]]
-        <h2>8. Additional Terms</h2>
-        <div class="custom-text">[[.Config.TermsText]]</div>
-        [[end]]
+        <div class="custom-text">[[safeHTML .Config.TermsText]]</div>
 
         <h2>Contact</h2>
         <p>Questions about these terms? Contact us:</p>

--- a/web-portal/src/components/CompanyForm.tsx
+++ b/web-portal/src/components/CompanyForm.tsx
@@ -757,6 +757,10 @@ const EditCompanyModal: React.FC<EditCompanyModalProps> = ({
                   </div>
                 </div>
 
+                <div className="sm:col-span-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900">
+                  <strong>Storefront pages</strong> render your text directly with no platform default content. Allowed HTML tags: <code>&lt;h2&gt;</code>, <code>&lt;p&gt;</code>, <code>&lt;br&gt;</code>, <code>&lt;strong&gt;</code>, <code>&lt;em&gt;</code>, <code>&lt;ul&gt;</code>, <code>&lt;li&gt;</code>. All other tags and attributes (links, images, scripts, styles) are escaped for safety.
+                </div>
+
                 <div className="sm:col-span-2">
                   <label className="block text-sm font-medium text-gray-700">About Us (shown on storefront homepage)</label>
                   <textarea
@@ -770,37 +774,37 @@ const EditCompanyModal: React.FC<EditCompanyModalProps> = ({
                 </div>
 
                 <div className="sm:col-span-2">
-                  <label className="block text-sm font-medium text-gray-700">Additional Privacy Policy (optional)</label>
+                  <label className="block text-sm font-medium text-gray-700">Privacy Policy</label>
                   <textarea
                     name="d2c.privacyText"
                     value={companyData.d2c?.privacyText || ''}
                     onChange={handleChange}
-                    rows={3}
-                    placeholder="Add company-specific privacy policies. A default policy is always included on your storefront."
+                    rows={5}
+                    placeholder="Your full privacy policy. If left blank the storefront privacy page will be empty."
                     className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-teal-500 focus:border-teal-500 sm:text-sm"
                   />
                 </div>
 
                 <div className="sm:col-span-2">
-                  <label className="block text-sm font-medium text-gray-700">Additional Terms of Service (optional)</label>
+                  <label className="block text-sm font-medium text-gray-700">Terms of Service</label>
                   <textarea
                     name="d2c.termsText"
                     value={companyData.d2c?.termsText || ''}
                     onChange={handleChange}
-                    rows={3}
-                    placeholder="Add company-specific terms. Default terms are always included on your storefront."
+                    rows={5}
+                    placeholder="Your full terms of service. If left blank the storefront terms page will be empty."
                     className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-teal-500 focus:border-teal-500 sm:text-sm"
                   />
                 </div>
 
                 <div className="sm:col-span-2">
-                  <label className="block text-sm font-medium text-gray-700">Additional Shipping & Returns Info (optional)</label>
+                  <label className="block text-sm font-medium text-gray-700">Shipping & Returns Policy</label>
                   <textarea
                     name="d2c.shippingText"
                     value={companyData.d2c?.shippingText || ''}
                     onChange={handleChange}
-                    rows={3}
-                    placeholder="Add shipping timelines, return windows, or specific policies. Default shipping info is always included."
+                    rows={5}
+                    placeholder="Your full shipping and returns policy. If left blank the storefront shipping page will be empty."
                     className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-teal-500 focus:border-teal-500 sm:text-sm"
                   />
                 </div>


### PR DESCRIPTION
…defaults); safeHTML allowlist (h2/p/br/strong/em/ul/li); CompanyForm shows allowed-tags hint; drop pre-wrap so HTML controls layout